### PR TITLE
Match blank lines with no whitespace as edit point

### DIFF
--- a/lib/action/editPoints.js
+++ b/lib/action/editPoints.js
@@ -24,7 +24,7 @@ define(function(require, exports, module) {
 		var content = String(editor.getContent());
 		var maxLen = content.length;
 		var nextPoint = -1;
-		var reEmptyLine = /^\s+$/;
+		var reEmptyLine = /^\s*$/;
 		
 		function getLine(ix) {
 			var start = ix;


### PR DESCRIPTION
Since it is common place to see whitespace removed from blank lines and line endings when editors save or when linters lint, I'd like to see edit points match totally blank lines as well.